### PR TITLE
ci: Pin all gh actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     name: Rust CI
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0
       - name: Install dependencies
         run: sudo apt-get install protobuf-compiler
       - name: Check code formatting

--- a/.github/workflows/run-coach.yml
+++ b/.github/workflows/run-coach.yml
@@ -38,10 +38,10 @@ jobs:
           echo "qdrant_version=$qdrant_version" >> $GITHUB_OUTPUT
           echo "coaching_time=$coaching_time" >> $GITHUB_OUTPUT
       - name: Install minimal stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
       # checkout coach
       - name: Checkout Coach
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Build Coach (release)
         run: cargo build --release
       - name: Coach things
@@ -53,7 +53,7 @@ jobs:
           ./coach-things.sh "$coaching_time" "$qdrant_version"
       - name: Send Notification
         if: failure() || cancelled()
-        uses: slackapi/slack-github-action@v1.26.0
+        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
         with:
           payload: |
             {


### PR DESCRIPTION
Pin all third-party GitHub Actions to commit SHAs. Version comments are preserved for readability and Dependabot compatibility.