### PR TITLE
ci: update third-party actions to node 24

### DIFF
--- a/.github/workflows/run-coach.yml
+++ b/.github/workflows/run-coach.yml
@@ -63,7 +63,7 @@ jobs:
           ./coach-things.sh "$coaching_time" "$qdrant_version"
       - name: Send Notification
         if: failure() || cancelled()
-        uses: slackapi/slack-github-action@70cd7be8e40a46e8b0eced40b0de447bdb42f68e # v1.26.0
+        uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
           payload: |
             {

--- a/.github/workflows/run-coach.yml
+++ b/.github/workflows/run-coach.yml
@@ -65,6 +65,8 @@ jobs:
         if: failure() || cancelled()
         uses: slackapi/slack-github-action@45a88b9581bfab2566dc881e2cd66d334e621e2c # v3.0.3
         with:
+          webhook: ${{ secrets.COACH_CHANNEL_WEBHOOK_URL }}
+          webhook-type: incoming-webhook
           payload: |
             {
               "text": "Coach run status: ${{ job.status }}",
@@ -78,6 +80,3 @@ jobs:
                 }
               ]
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.COACH_CHANNEL_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK


### PR DESCRIPTION
Update all third-party GitHub Actions to Node 24-compatible versions before the June 2 deadline.